### PR TITLE
添加行情分钟的基本接口

### DIFF
--- a/client/market_data.go
+++ b/client/market_data.go
@@ -165,3 +165,19 @@ func (api *TuShare) Suspend(params map[string]string, fields []string) (*APIResp
 
 	return api.postData(body)
 }
+
+// StkMins 分钟数据
+// params: ts_code / start_date / end_date / freq / offset / limit
+// params example: 601965.SH / 2024-05-27 09:30:00 / 2024-05-27 15:00:00 / 1min / 0 / 10
+// return: code股票代码 / tradetime交易时间 / open开盘价 / close收盘价 / high最高价 / low最低价 / vol成交量 / amount成交额(元)
+// return example: [[601965.SH 2024-05-28 15:00:00 18.69 18.69 18.69 18.69 40700 760683]]
+func (api *TuShare) StkMins(params map[string]string, fields []string) (*APIResponse, error) {
+	body := map[string]interface{}{
+		"api_name": "stk_mins",
+		"token":    api.token,
+		"params":   params,
+		"fields":   fields,
+	}
+
+	return api.postData(body)
+}


### PR DESCRIPTION
描述：

添加行情分钟的基本接口，该接口不展示于文档（可参考 Python 源码）。

对应接口参数、响应信息请使用者直接参考本包源码即可。

备注：并未完整实现 `pro_bar` 接口，利用该接口，已经可以直接获取分钟线。

关联：https://github.com/yushikuann/go-tushare-sdk/issues/1